### PR TITLE
Show all stack info on tooltip and update stack info on statusbar

### DIFF
--- a/src/gotosymbolstack.ts
+++ b/src/gotosymbolstack.ts
@@ -14,7 +14,7 @@ export class GoToSymbolStack {
     private _statusBarItem: vscode.StatusBarItem;
     constructor() {
         if (!this._statusBarItem) {
-            this._statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+            this._statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
         }
         /* get the current text editor */
         let editor = vscode.window.activeTextEditor;
@@ -42,6 +42,7 @@ export class GoToSymbolStack {
         let tooltip = "";
         let stackCnt = 1;
         this.filePosStack.forEach(filePos => {
+            //vscode.window.activeTextEditor.document.offsetAt(filePos.textPosition)
             tooltip = (stackCnt++) + ") " + this.getRelativePath(filePos.textFile) + " (" + filePos.textPosition.line + ")" + "\n" + tooltip;
         });
         this._statusBarItem.tooltip = tooltip; 
@@ -49,9 +50,9 @@ export class GoToSymbolStack {
 
     updateCurrent() {
         if (this.crtStackIndex > 0) {
-            this._statusBarItem.text = "Stack: " + this.getRelativePath(this.filePosStack[this.crtStackIndex - 1].textFile) + " (" + this.crtStackIndex + "/" + this.maxStackIndex + ")"; 
+            this._statusBarItem.text = `$(link-external) ` + this.getRelativePath(this.filePosStack[this.crtStackIndex - 1].textFile) + " (" + this.crtStackIndex + "/" + this.maxStackIndex + ")"; 
         } else {
-            this._statusBarItem.text = "Stack: " + this.crtStackIndex + "/" + this.maxStackIndex;
+            this._statusBarItem.text = `$(link-external) ` + this.crtStackIndex + "/" + this.maxStackIndex;
         }
     }
     goToFilePosition(vStackIdx: number) {


### PR DESCRIPTION
This is my first pull request on github.
So, If I have been disrespectful, I do not know what to do, so please understand.

This commit can tell you which files have jumped through the status bar. And when you hover the mouse, you can see the information accumulated in the stack through the tooltip.
In addition, the file path is represented as a relative path if the file is a working directory path, or an absolute path if the file is outside the working directory.

Then have a good day.